### PR TITLE
replace XMLHttpRequest with FetchAPI

### DIFF
--- a/token.html
+++ b/token.html
@@ -90,19 +90,21 @@
     <script src="js/clipboard.min.js"></script>
 
     <script type="text/javascript">
-        const http = new XMLHttpRequest();
-        http.open("GET", "/token");
-        http.send();
-        http.onload = () => {
-            const base64Url = http.responseText.split('.')[1];
-            const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-            const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
-                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-            }).join(''));
-            document.getElementById("sub").innerHTML = JSON.parse(jsonPayload)['sub'];
-            document.getElementById("token").innerHTML = http.responseText;
-        }
-        new ClipboardJS('.btn');
+        fetch('/token')
+            .then(response => response.text())
+            .then(responseText => {
+                const base64Url = responseText.split('.')[1];
+                const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+                const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+                    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+                }).join(''));
+                document.getElementById("sub").innerHTML = JSON.parse(jsonPayload)['sub'];
+                document.getElementById("token").innerHTML = responseText;
+                new ClipboardJS('.btn');
+            })
+            .catch(error => {
+                console.error('Fetch error:', error);
+            });
     </script>
 
     </body>


### PR DESCRIPTION
This is just a maintenance update. While the old API isn't deprecated, it's also not the most idiomatic way of using it.
This is an easy update but should probably be checked with the localega-tsd-proxy to ensure that we are still getting the correct response back.